### PR TITLE
coin slotのテストを新規追加

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,3 +1,3 @@
 {
-  "presets": ["react"]
+  "presets": ["es2015", "react"]
 }

--- a/package.json
+++ b/package.json
@@ -4,11 +4,14 @@
   "description": "React.jsとElectronで作る自販機",
   "scripts": {
     "start": "electron .",
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "mocha --compilers js:babel-register --recursive"
   },
   "license": "MIT",
   "devDependencies": {
+    "babel-preset-es2015": "^6.6.0",
     "electron-prebuilt": "^0.37.2",
+    "expect": "^1.16.0",
+    "mocha": "^2.4.5",
     "redux-devtools": "^3.1.1"
   },
   "repository": {

--- a/test/insert-money.js
+++ b/test/insert-money.js
@@ -1,0 +1,27 @@
+var expect = require('expect');
+var vendingMachineReducer = require('../src/reducers/vending-machine');
+console.log(expect);
+
+describe('VendingMachine reducers', () => {
+  it('初期状態', () => {
+    expect(
+      vendingMachineReducer(undefined, {})
+    ).toEqual({
+      amountOfMoney: 0,
+    });
+  });
+
+  describe('お金の投入', () => {
+    it('10円入れる', () => {
+      expect(
+        vendingMachineReducer(undefined, {
+          type: 'INSERT_MONEY',
+          value: 10,
+        })
+      ).toEqual({
+        amountOfMoney: 10,
+      });
+    });
+  });
+});
+


### PR DESCRIPTION
- mochaの設定
- お金の投入テストを作成

`npm test` でテストを実行できます。
